### PR TITLE
Remove allowBackup attribute

### DIFF
--- a/api/src/main/AndroidManifest.xml
+++ b/api/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="se.emilsjolander.api">
 
-    <application android:allowBackup="true">
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
To fix below error:

```
Error:Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:9:9-36
    is also present at [se.emilsjolander:intentbuilder-api:0.14.0] AndroidManifest.xml:9:18-44 value=(true).
    Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:7:5-29:19 to override.
```
